### PR TITLE
Replace old version of clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,17 +100,41 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -388,7 +403,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "structopt",
  "url",
  "walkdir",
 ]
@@ -420,12 +434,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -762,6 +773,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,33 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1131,12 +1124,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
@@ -1293,12 +1283,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1321,12 +1305,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 build = "build.rs"
 
 [dependencies]
-clap = "2"
-structopt = "0.3"
+clap = { version = "3.2", features = ["cargo", "color", "derive", "suggestions"] }
 itertools = "0.10"
 regex = "1.5"
 log = "0.4"

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,23 +1,24 @@
 use std::str::FromStr;
 
 use crate::cmd;
+use clap::Parser;
 use dialoguer::theme::{ColorfulTheme, SimpleTheme, Theme};
 
-#[derive(Debug, StructOpt)]
-#[structopt(name = "goto", about = "Web bookmarks utility")]
+#[derive(Debug, Parser)]
+#[clap(author, version, about = "Web bookmarks utility")]
 pub struct Config {
     /// Set verbosity level, 0 - 5
     ///
     /// Set the verbosity level, from 0 (least amount of output) to 5 (most verbose). Note that
     /// logging level configured via RUST_LOG overrides this setting.
-    #[structopt(short, long = "verbosity", default_value = "1")]
+    #[clap(short, long = "verbosity", default_value = "1")]
     pub verbosity_level: u8,
 
     /// Print debug information
     ///
     /// Print debug information about current build for binary, useful for when an issue is
     /// encountered and reported
-    #[structopt(short = "D", long = "debug")]
+    #[clap(short = 'D', long = "debug")]
     pub print_dbg: bool,
     /// Set use of colors
     ///
@@ -25,9 +26,9 @@ pub struct Config {
     /// try to figure out if colors are supported by the terminal in the current context, and use it
     /// if possible.
     /// Possible values are "on", "true", "off", "false", "auto".
-    #[structopt(long = "colors", default_value = "auto")]
+    #[clap(long = "colors", default_value = "auto")]
     colors: Flag,
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub cmd: cmd::Command,
 }
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -4,6 +4,7 @@ use crate::{
     tag::{Tag, TagHolder},
     Error,
 };
+use clap::Subcommand;
 use dialoguer::{console::Term, theme::Theme, FuzzySelect, Select};
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -16,7 +17,7 @@ use std::{
 use std::{iter::FromIterator, path::Path};
 use url::Url;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 pub enum Command {
     /// Add bookmark with URL
     ///
@@ -28,7 +29,7 @@ pub enum Command {
     /// match the keywords, the best matching bookmark will be selected. If no bookmark is matching
     /// the keywords, the keywords will be directed to a search query in a search engine.
     Open {
-        #[structopt(short = "s", long = "score", default_value = "0.05")]
+        #[clap(short = 's', long = "score", default_value = "0.05")]
         min_score: f64,
         keywords: Vec<Tag>,
     },
@@ -36,9 +37,9 @@ pub enum Command {
     ///
     /// Select from a list of bookmarks
     Select {
-        #[structopt(short = "s", long = "score", default_value = "0.05")]
+        #[clap(short = 's', long = "score", default_value = "0.05")]
         min_score: f64,
-        #[structopt(short = "n", long, default_value = "8192")]
+        #[clap(short = 'n', long, default_value = "8192")]
         limit: usize,
         keywords: Vec<Tag>,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate structopt;
-
 mod bookmark;
 mod cfg;
 mod cmd;
@@ -14,13 +11,13 @@ mod tag;
 use crate::cfg::Config;
 use crate::dbg::dbg_info;
 use crate::logger::setup_logging;
+use clap::Parser;
 use dialoguer::theme::Theme;
 use std::io::Write;
 use std::{path::PathBuf, process};
-use structopt::StructOpt;
 
 fn main() -> Result<(), Error> {
-    let cfg: Config = Config::from_args();
+    let cfg: Config = Config::parse();
     setup_logging(cfg.verbosity_level);
 
     let stream = std::io::stdout();

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -43,6 +43,8 @@ impl Display for TagError {
     }
 }
 
+impl std::error::Error for TagError {}
+
 impl Display for Tag {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)


### PR DESCRIPTION
Replace old version of clap 2 and usage of structopt with clap 3.2.

Closes #6 