### PR TITLE
ci: replace token-based rust check actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,8 +10,11 @@ on:
 jobs:
   security_audit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --locked
+      - name: Run cargo-audit
+        run: cargo audit

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,12 +33,12 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - run: rustup component add clippy
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+      - name: clippy
+        run: cargo clippy --all-features
       - name: rustfmt
         run: rustfmt --check src/*


### PR DESCRIPTION
Use cargo clippy and cargo audit directly in workflows.

This avoids Dependabot token permission failures.